### PR TITLE
Pull in upstream from gorilla/csrf

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ goji/csrf is easy to use: add the middleware to your stack with the below:
 goji.Use(csrf.Protect([]byte("32-byte-long-auth-key")))
 ```
 
-... and then collect the token with `csrf.Token(c, r)` before passing it to the 
-template, JSON body or HTTP header (you pick!). goji/csrf inspects the form body 
-(first) and HTTP headers (second) on subsequent POST/PUT/PATCH/DELETE/etc. requests 
-for the token.
+... and then collect the token with `csrf.Token(c, r)` before passing it to the
+template, JSON body or HTTP header (you pick!). goji/csrf inspects HTTP headers
+(first) and the form body (second) on subsequent POST/PUT/PATCH/DELETE/etc.
+requests for the token.
 
 ### HTML Forms
 

--- a/csrf.go
+++ b/csrf.go
@@ -70,6 +70,7 @@ type options struct {
 	RequestHeader string
 	FieldName     string
 	ErrorHandler  web.Handler
+	CookieName    string
 }
 
 // Protect is HTTP middleware that provides Cross-Site Request Forgery

--- a/csrf.go
+++ b/csrf.go
@@ -132,6 +132,10 @@ func Protect(authKey []byte, opts ...func(*csrf) error) func(*web.C, http.Handle
 			cs.opts.FieldName = fieldName
 		}
 
+		if cs.opts.CookieName == "" {
+			cs.opts.CookieName = cookieName
+		}
+
 		if cs.opts.RequestHeader == "" {
 			cs.opts.RequestHeader = headerName
 		}

--- a/csrf.go
+++ b/csrf.go
@@ -139,6 +139,8 @@ func Protect(authKey []byte, opts ...func(*csrf) error) func(*web.C, http.Handle
 		// Create an authenticated securecookie instance.
 		if cs.sc == nil {
 			cs.sc = securecookie.New(authKey, nil)
+			// Use JSON serialization (faster than one-off gob encoding)
+			cs.sc.SetSerializer(securecookie.JSONEncoder{})
 			// Set the MaxAge of the underlying securecookie.
 			cs.sc.MaxAge(cs.opts.MaxAge)
 		}

--- a/csrf.go
+++ b/csrf.go
@@ -146,9 +146,13 @@ func Protect(authKey []byte, opts ...func(*csrf) error) func(*web.C, http.Handle
 		if cs.st == nil {
 			// Default to the cookieStore
 			cs.st = &cookieStore{
-				name:   cookieName,
-				maxAge: cs.opts.MaxAge,
-				sc:     cs.sc,
+				name:     cs.opts.CookieName,
+				maxAge:   cs.opts.MaxAge,
+				secure:   cs.opts.Secure,
+				httpOnly: cs.opts.HttpOnly,
+				path:     cs.opts.Path,
+				domain:   cs.opts.Domain,
+				sc:       cs.sc,
 			}
 		}
 

--- a/csrf_test.go
+++ b/csrf_test.go
@@ -260,6 +260,8 @@ func TestWithReferer(t *testing.T) {
 	rr = httptest.NewRecorder()
 	s.ServeHTTP(rr, r)
 
+	t.Log(r.Header)
+
 	if rr.Code != http.StatusOK {
 		t.Fatalf("middleware failed to pass to the next handler: got %v want %v",
 			rr.Code, http.StatusOK)

--- a/helpers.go
+++ b/helpers.go
@@ -91,11 +91,9 @@ func unmask(issued []byte) []byte {
 // requestToken returns the issued token (pad + masked token) from the HTTP POST
 // body or HTTP header. It will return nil if the token fails to decode.
 func (cs *csrf) requestToken(r *http.Request) []byte {
-	// Check the POST (form) value first.
-	issued := r.PostFormValue(cs.opts.FieldName)
+	issued := r.Header.Get(cs.opts.RequestHeader)
 	if issued == "" {
-		// Fall back to the HTTP header
-		issued = r.Header.Get(cs.opts.RequestHeader)
+		issued = r.PostFormValue(cs.opts.FieldName)
 	}
 
 	// Decode the "issued" (pad + masked) token sent in the request. Return a

--- a/options.go
+++ b/options.go
@@ -92,6 +92,17 @@ func FieldName(name string) func(*csrf) error {
 	}
 }
 
+// CookieName changes the name of the CSRF cookie issued to clients.
+//
+// Note that cookie names should not contain whitespace, commas, semicolons,
+// backslashes or control characters as per RFC6265.
+func CookieName(name string) func(*csrf) error {
+	return func(cs *csrf) error {
+		cs.opts.CookieName = name
+		return nil
+	}
+}
+
 // setStore sets the store used by the CSRF middleware.
 // Note: this is private (for now) to allow for internal API changes.
 func setStore(s store) func(*csrf) error {

--- a/options_test.go
+++ b/options_test.go
@@ -18,6 +18,7 @@ func TestOptions(t *testing.T) {
 	header := "X-AUTH-TOKEN"
 	field := "authenticity_token"
 	errorHandler := unauthorizedHandler
+	name := "_goji_goji_goji"
 
 	testOpts := []func(*csrf) error{
 		MaxAge(age),
@@ -28,6 +29,7 @@ func TestOptions(t *testing.T) {
 		RequestHeader(header),
 		FieldName(field),
 		ErrorHandler(web.HandlerFunc(errorHandler)),
+		CookieName(name),
 	}
 
 	// Parse our test options and check that they set the related struct fields.
@@ -64,5 +66,10 @@ func TestOptions(t *testing.T) {
 	if !reflect.ValueOf(cs.opts.ErrorHandler).IsValid() {
 		t.Errorf("ErrorHandler not set correctly: got %v want %v",
 			reflect.ValueOf(cs.opts.ErrorHandler).IsValid(), reflect.ValueOf(errorHandler).IsValid())
+	}
+
+	if cs.opts.CookieName != name {
+		t.Errorf("CookieName not set correctly: got %v want %v",
+			cs.opts.CookieName, name)
 	}
 }

--- a/store.go
+++ b/store.go
@@ -59,9 +59,13 @@ func (cs *cookieStore) Save(token []byte, w http.ResponseWriter) error {
 	}
 
 	cookie := &http.Cookie{
-		Name:   cs.name,
-		Value:  encoded,
-		MaxAge: cs.maxAge,
+		Name:     cs.name,
+		Value:    encoded,
+		MaxAge:   cs.maxAge,
+		HttpOnly: cs.httpOnly,
+		Secure:   cs.secure,
+		Path:     cs.path,
+		Domain:   cs.domain,
 	}
 
 	// Set the Expires field on the cookie based on the MaxAge

--- a/store.go
+++ b/store.go
@@ -22,9 +22,13 @@ type store interface {
 
 // cookieStore is a signed cookie session store for CSRF tokens.
 type cookieStore struct {
-	name   string
-	maxAge int
-	sc     *securecookie.SecureCookie
+	name     string
+	maxAge   int
+	secure   bool
+	httpOnly bool
+	path     string
+	domain   string
+	sc       *securecookie.SecureCookie
 }
 
 // Get retrieves a CSRF token from the session cookie. It returns an empty token

--- a/store_test.go
+++ b/store_test.go
@@ -67,7 +67,7 @@ func TestCookieDecode(t *testing.T) {
 	// Test with a nil hash key
 	sc := securecookie.New(nil, nil)
 	sc.MaxAge(age)
-	st := &cookieStore{cookieName, age, sc}
+	st := &cookieStore{cookieName, age, true, true, "", "", sc}
 
 	// Set a fake cookie value so r.Cookie passes.
 	r.Header.Set("Cookie", fmt.Sprintf("%s=%s", cookieName, "notacookie"))
@@ -85,7 +85,7 @@ func TestCookieEncode(t *testing.T) {
 	// Test with a nil hash key
 	sc := securecookie.New(nil, nil)
 	sc.MaxAge(age)
-	st := &cookieStore{cookieName, age, sc}
+	st := &cookieStore{cookieName, age, true, true, "", "", sc}
 
 	rr := httptest.NewRecorder()
 


### PR DESCRIPTION
- Added a `CookieName` function
- Inspect HTTP headers first before we parse the form values
- Fix a bug where the cookie Path, Domain, Secure & HttpOnly were not being set on the underlying cookie.
- Changed to use `securecookie.JSONEncoder{}` - faster than gob and our data will always be JSON compatible by default.
